### PR TITLE
Fixed the lit texture shader (on my hardware, at least)

### DIFF
--- a/MapBuilder.cs
+++ b/MapBuilder.cs
@@ -143,7 +143,7 @@ public class MapBuilder {
 			newObj.AddComponent<MeshCollider>().sharedMesh = mesh;
 			if (map.sectors[index].floorTexture != "F_SKY1") {
 				mr.material = doomMaterial;
-				mr.material.SetTexture("_RenderMap", GetFlat(map.sectors[index].floorTexture));
+				mr.material.SetTexture("_MainTex", GetFlat(map.sectors[index].floorTexture));
 				mr.material.SetFloat("_Brightness", brightness);
 			} else {
 				mr.material = skyMaterial;
@@ -165,7 +165,7 @@ public class MapBuilder {
 			mr = newObj.AddComponent<MeshRenderer>();
 			if (map.sectors[index].ceilingTexture != "F_SKY1") {
 				mr.material = doomMaterial;
-				mr.material.SetTexture("_RenderMap", GetFlat(map.sectors[index].ceilingTexture));
+				mr.material.SetTexture("_MainTex", GetFlat(map.sectors[index].ceilingTexture));
 				mr.material.SetFloat("_Brightness", brightness);
 			} else {
 				mr.material = skyMaterial;
@@ -348,7 +348,7 @@ public class MapBuilder {
 			mr.material = skyMaterial;
 		} else {
 			mr.material = doomMaterial;
-			mr.material.SetTexture("_RenderMap", tex);
+			mr.material.SetTexture("_MainTex", tex);
 			mr.material.SetFloat("_Brightness", light);
 		}
 		newObj.AddComponent<MeshFilter>().mesh = mesh;

--- a/texture.shader
+++ b/texture.shader
@@ -3,11 +3,11 @@
 Shader "Doom/Texture" {
  
 Properties {
-    _RenderMap ("Render Map", 2D) = "white" {}
+    _MainTex ("Render Map", 2D) = "white" {}
     _Palette ("Palette", 2D) = "white" {}
     _Colormap ("Colormap", 2D) = "white" {}
     _Brightness ("Brightness", float) = 1.0
-    _DepthImpact("Depth Impact", float) = 1.0
+//  _DepthImpact("Depth Impact", float) = 1.0
 }
 
 SubShader {
@@ -18,48 +18,36 @@ SubShader {
 
     Pass {  
         CGPROGRAM
-// Upgrade NOTE: excluded shader from DX11; has structs without semantics (struct v2f members depth)
-#pragma exclude_renderers d3d11
             #pragma vertex vert
             #pragma fragment frag
 
             #include "UnityCG.cginc"
 
-            /*
-            struct appdata_t {
-                float4 vertex : POSITION;
-                float2 texcoord : TEXCOORD0;
-            };
-            */
-
             struct v2f {
                 float4 vertex : SV_POSITION;
                 float2 texcoord : TEXCOORD0;
-                float2 depth : TEXCOORD1;
+                float depth : TEXCOORD1;
             };
 
-            sampler2D _RenderMap;
+            sampler2D _MainTex;
             sampler2D _Palette;
             sampler2D _Colormap;
-            //uniform sampler2D _CameraDepthTexture;
             float _Brightness;
-            float4 _RenderMap_ST;
+            float4 _MainTex_ST;
+        //  float _DepthImpact;
 
             v2f vert (appdata_base v)
             {
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
-
-                o.depth = o.vertex.z;
-                
-                o.texcoord = TRANSFORM_TEX(v.texcoord, _RenderMap);
+                o.depth = length(WorldSpaceViewDir(v.vertex));
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
                 float depth = saturate(1.0 - (i.depth) * 0.1);
-
                 float li = (_Brightness * 2.0) - (224.0 / 256.0);
                 li = saturate(li);
                 float maxlight = (_Brightness * 2.0) - (40.0 / 256.0);
@@ -69,9 +57,9 @@ SubShader {
 
 
 
-                float indexCol = tex2D(_RenderMap, i.texcoord).r;
+                float indexCol = tex2D(_MainTex, i.texcoord).r;
 
-                float alpha = tex2D(_RenderMap, i.texcoord).a;
+                float alpha = tex2D(_MainTex, i.texcoord).a;
                 float colormapIndex = indexCol;
                 float brightnessLookup = (floor((1.0-odepth) * 32.0)) / 32.0;
 

--- a/unlittexture.shader
+++ b/unlittexture.shader
@@ -22,13 +22,6 @@ SubShader {
 
             #include "UnityCG.cginc"
 
-            /*
-            struct appdata_t {
-                float4 vertex : POSITION;
-                float2 texcoord : TEXCOORD0;
-            };
-            */
-
             struct v2f {
                 float4 vertex : SV_POSITION;
                 float2 texcoord : TEXCOORD0;


### PR DESCRIPTION
The lit shader showed up pink and utterly tanked my FPS, but without any errors or warnings. Presumably this was because DX 11 was disabled, but the shader works fine (again, on my machine) with 11.

I also couldn't figure out how to make the depth work properly with your setup, so I changed that line and it now works for me too- not sure if I've messed up your calibration to get it looking correct though! Looks roughly correct from memory though.

Changed _RenderMap to _MainTex so you can flip between lit and unlit shaders for debugging too.

Your included scene doesn't work by the way, I think Unity relies on the .meta files to identify which scripts are attached to gameobjects. I rebuilt one that seems to work, but I was thinking about just writing a single script that initializes the whole scene hierarchy manually. :)
