### PR TITLE
Fixes build_wad.py so it ignores .meta files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ For Midi, you must have a soundfont file in the root directory, and merge in a w
 The IWADS use MUS files and those are not supported yet.
 
 To build the engine wad: you need to have python 3, omgifol, and pillow
-`pip install omgifol`
+
+`pip install omgifol`  
 `pip install pillow`
+
 you will want to change the path to the root directory of the project or build.
 then just run `python3 build_wad.py` to generate the engine wad.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Drop the "DoomUnity" folder into your project and try some stuff out!
 `MapData map = new MapData(wad, "MAP01");`
 `Texture2D impSprite = DoomGraphic.BuildPatch("TROOA1", wad);`
 
-To run the engine stuff, you'll need to put `nasty.wad` and (at least one) IWAD in the root folder of your project (just below Assets).
+To run the engine stuff, you'll need to generate `nasty.wad` and put that and (at least one) IWAD in the root folder of your project (just below Assets).
 
 For Midi, you must have a soundfont file in the root directory, and merge in a wad with MIDI files.
 The IWADS use MUS files and those are not supported yet.
 
-To build the engine wad: you need to have python 3 and omgifol
+To build the engine wad: you need to have python 3, omgifol, and pillow
 `pip install omgifol`
+`pip install pillow`
 you will want to change the path to the root directory of the project or build.
 then just run `python3 build_wad.py` to generate the engine wad.
 

--- a/build_wad.py
+++ b/build_wad.py
@@ -8,6 +8,9 @@ wadfilespath = "enginewad/"
 wad = omg.WAD()
 files = [f for f in listdir(wadfilespath) if isfile(join(wadfilespath, f))]
 for f in files:
+	ext = f.find('.meta')
+	if ext != -1:
+		continue
 	ext = f[f.find('.')+1:]
 	if ext == "png":
 		graphic = omg.Graphic()


### PR DESCRIPTION
.meta files are automatically generated if the enginewad dir is inside a Unity project, and they cause the wad building to fail horribly. :)

Also updates the readme to mention the pillow dependency.