### PR TITLE
Fix for midi/soundfont checking.

### DIFF
--- a/GameSetup.cs
+++ b/GameSetup.cs
@@ -81,11 +81,13 @@ public class GameSetup : MonoBehaviour {
 
 		if (args.soundfont == "") midiEnabled = false;
 
-		if (File.Exists(args.soundfont) && midiEnabled) {
-			midiPlayer = gameObject.AddComponent<MidiPlayer>();
-			midiPlayer.LoadBank(new PatchBank(File.OpenRead(args.soundfont)));
-		} else {
-			Debug.LogError("No soundfont found, disabling midi");
+		if (midiEnabled) {
+			if (File.Exists(args.soundfont)) {
+				midiPlayer = gameObject.AddComponent<MidiPlayer>();
+				midiPlayer.LoadBank(new PatchBank(File.OpenRead(args.soundfont)));
+			} else {
+				Debug.LogError("No soundfont found, disabling midi");
+			}
 		}
 
 		cheatCodes = new List<string>() {


### PR DESCRIPTION
Even with midis disabled (whether from just being disabled, or because no soundfont was specified) it would throw the "No soundfont found, disabling midi" error.