### PR TITLE
Improved sky rendering to support bigger and differently proportioned textures.

### DIFF
--- a/sky.shader
+++ b/sky.shader
@@ -28,7 +28,7 @@ SubShader {
 
             sampler2D _RenderMap;
             sampler2D _Palette;
-            float4 _RenderMap_ST;
+            float4 _RenderMap_TexelSize;
             float _CameraAngle;
 
             v2f vert (appdata_base v)
@@ -40,9 +40,9 @@ SubShader {
 
             fixed4 frag (v2f i) : SV_Target
             {
-                float2 texcoord=i.vertex / _ScreenParams.xy;
-                texcoord.x += (_CameraAngle * (3.0/360)) ;
-                texcoord.y = 1.0 - texcoord.y;
+                float2 texcoord = i.vertex / _ScreenParams.xy;
+                texcoord.x += (_CameraAngle * (3.0/360));
+                texcoord.y = -texcoord.y * (_RenderMap_TexelSize.z / _RenderMap_TexelSize.w) * 0.5;
                 float indexCol = tex2D(_RenderMap, texcoord).r;
                 float4 col = tex2D(_Palette, float2(indexCol + (.5/256.0), 0.0));
                 return col;


### PR DESCRIPTION
I've only tested it with DOOM2.WAD and the sky from the first Saturn X map, but it's identical for D2, and looks much better for Saturn X (although I'm not sure how most ports/the original engine handled larger sky textures, so it's possible I need to adjust the scale)

Before:
![Before](https://user-images.githubusercontent.com/734762/34315633-2ecc88f4-e748-11e7-9082-40f0cf012c85.png)
After:
![After](https://user-images.githubusercontent.com/734762/34315625-18f448f0-e748-11e7-9025-3cfbed1fe9a0.png)
