### PR TITLE
Updated shaders.

### DIFF
--- a/sky.shader
+++ b/sky.shader
@@ -5,14 +5,12 @@ Shader "Doom/Sky" {
 Properties {
     _RenderMap ("Render Map", 2D) = "white" {}
     _Palette ("Palette", 2D) = "white" {}
-    _CameraAngle ("Camera Angle", float) = 1.0
+    _CameraAngle ("Camera Angle", float) = 0.0
 }
 
 SubShader {
-    Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Opaque"}
+    Tags {"Queue"="Geometry" "IgnoreProjector"="True" "RenderType"="Opaque"}
     LOD 200
-
-    Blend SrcAlpha OneMinusSrcAlpha 
 
     Pass {  
         CGPROGRAM
@@ -40,9 +38,9 @@ SubShader {
 
             fixed4 frag (v2f i) : SV_Target
             {
-                float2 texcoord = i.vertex / _ScreenParams.xy;
+                float2 texcoord = -i.vertex / _ScreenParams.zw;
                 texcoord.x += (_CameraAngle * (3.0/360));
-                texcoord.y = -texcoord.y * (_RenderMap_TexelSize.z / _RenderMap_TexelSize.w) * 0.5;
+                texcoord.y = texcoord.y * (_RenderMap_TexelSize.z / _RenderMap_TexelSize.w) * 0.5;
                 float indexCol = tex2D(_RenderMap, texcoord).r;
                 float4 col = tex2D(_Palette, float2(indexCol + (.5/256.0), 0.0));
                 return col;

--- a/texture.shader
+++ b/texture.shader
@@ -10,10 +10,8 @@ Properties {
 }
 
 SubShader {
-    Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Opaque"}
+    Tags {"Queue"="Geometry" "IgnoreProjector"="True" "RenderType"="Opaque"}
     LOD 200
-
-    Blend SrcAlpha OneMinusSrcAlpha 
 
     Pass {  
         CGPROGRAM
@@ -25,7 +23,6 @@ SubShader {
             struct v2f {
                 float4 vertex : SV_POSITION;
                 float2 texcoord : TEXCOORD0;
-                float depth : TEXCOORD1;
             };
 
             sampler2D _MainTex;
@@ -38,21 +35,19 @@ SubShader {
             {
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
-                o.depth = o.vertex.z;
                 o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
-                float depth = saturate(1.0 - (i.depth) * 0.1);
+                float depth = saturate(i.vertex.z);
                 float li = (_Brightness * 2.0) - (224.0 / 256.0);
                 li = saturate(li);
                 float maxlight = (_Brightness * 2.0) - (40.0 / 256.0);
                 maxlight = saturate(maxlight);
                 float dscale = depth * 0.4;
                 float odepth = saturate(li + dscale) + 0.01;
-
 
 
                 float indexCol = tex2D(_MainTex, i.texcoord).r;

--- a/unlittexture.shader
+++ b/unlittexture.shader
@@ -10,10 +10,8 @@ Properties {
 }
 
 SubShader {
-    Tags {"Queue"="Geometry" "IgnoreProjector"="True" "RenderType"="Transparent"}
+    Tags {"Queue"="Geometry" "IgnoreProjector"="True" "RenderType"="Opaque"}
     LOD 200
-
-    Blend SrcAlpha OneMinusSrcAlpha 
 
     Pass {  
         CGPROGRAM


### PR DESCRIPTION
Main changes are moving everything back to the opaque geo queue/render type, removing the blending too.

The sky is mostly unchanged, but is now flipped correctly.

texture.shader now works for me again and looks very roughly equivalent to chocolate doom, and I haven't noticed the weird problem from before. Let me know if you have any issues and I'll get back to working on the sky shader.